### PR TITLE
refactor:

### DIFF
--- a/configx/config.go
+++ b/configx/config.go
@@ -685,7 +685,6 @@ func (dod *DODServer) parse() error {
 				return conn.Close()
 			},
 			IdleTimeout: dod.Pool.idleTimeoutDuration,
-			WaitTimeout: dod.Pool.waitTimeoutDuration,
 		}
 		cpt, err := libnamed.NewConnectionPool(cpf)
 		if err != nil {
@@ -842,7 +841,6 @@ func (dot *DOTServer) parse() error {
 				return conn.Close()
 			},
 			IdleTimeout: dot.Pool.idleTimeoutDuration,
-			WaitTimeout: dot.Pool.waitTimeoutDuration,
 		}
 		cpt, err := libnamed.NewConnectionPool(cpf)
 		if err != nil {

--- a/configx/constants.go
+++ b/configx/constants.go
@@ -37,6 +37,7 @@ const (
 	DefaultPoolIdleTimeoutDuration = 30 * time.Second
 	DefaultPoolWaitTimeoutDuration = 3 * time.Second
 	DefaultPoolSize                = 5
+	DefaultPoolQueriesPerConn      = 32
 
 	DefaultDnsOptDnssec       = false
 	DefaultDnsOptEcs          = false

--- a/libnamed/connection_pool.go
+++ b/libnamed/connection_pool.go
@@ -15,10 +15,6 @@ import (
  * Simple ConnectionPool - FIFO with global lock
  */
 
-var (
-	defaultMaxReqs = 32
-)
-
 type ConnectionPool struct {
 	MaxConn     int
 	MaxReqs     int
@@ -46,13 +42,14 @@ func NewConnectionPool(cp *ConnectionPool) (*ConnectionPool, error) {
 	if cp.NewConn == nil || cp.IsValidConn == nil || cp.CloseConn == nil {
 		return nil, errors.New("connection pool no valid function 'NewConn' || 'IsValidConn' || 'CloseConn'")
 	}
-	maxReqs := cp.MaxReqs
-	if maxReqs <= 0 {
-		maxReqs = defaultMaxReqs
+
+	if cp.MaxConn <= 0 || cp.MaxReqs <= 0 {
+		return nil, nil
 	}
+
 	return &ConnectionPool{
 		MaxConn:     cp.MaxConn,
-		MaxReqs:     maxReqs,
+		MaxReqs:     cp.MaxReqs,
 		NewConn:     cp.NewConn,
 		IsValidConn: cp.IsValidConn,
 		CloseConn:   cp.CloseConn,

--- a/queryx/query_over_tls.go
+++ b/queryx/query_over_tls.go
@@ -24,23 +24,26 @@ func queryDoT(dc *libnamed.DConnection, dot *configx.DOTServer) (*dns.Msg, error
 	var rtt time.Duration
 
 	if dot.ConnectionPool != nil {
-		conn, _rtt, cached, _err := dot.ConnectionPool.Get()
+		ce, _rtt, cached, _err := dot.ConnectionPool.Get()
+
 		subEvent.Dur("connection_pool_latency", _rtt).Bool("connection_pool_hit", cached).AnErr("connection_pool_error", _err)
 		if _err == nil {
-			subEvent.Uint64("connection_pointer", *(*uint64)(unsafe.Pointer(&conn)))
-			resp, rtt, err = dot.Client.ExchangeWithConn(r, conn)
+			subEvent.Uint64("connection_pointer", *(*uint64)(unsafe.Pointer(&ce.Conn)))
+			resp, rtt, err = dot.Client.ExchangeWithConn(r, ce.Conn)
+			if err != nil {
+				ce.Conn.Close()
+				ce.Conn = nil
+			}
+			dot.ConnectionPool.Put(ce)
 		} else {
+			var conn *dns.Conn
 			conn, err = dot.NewConn(dot.Client.Net)
 			if err == nil {
 				resp, rtt, err = dot.Client.ExchangeWithConn(r, conn)
+				conn.Close()
 			} else {
 				subEvent.Err(err)
 			}
-		}
-		if err == nil {
-			dot.ConnectionPool.Put(conn)
-		} else if conn != nil {
-			conn.Close()
 		}
 	} else {
 		var conn *dns.Conn


### PR DESCRIPTION
1. use `idleTimeout` and `queriesPerConn` to determine a reuseable connection
2. `size` only limit connection pool size, not limit outgoing connection, that's what rate limit do
